### PR TITLE
Fixed issue where pop() could cause a crash due to an empty notifQueue

### DIFF
--- a/ABNScheduler.swift
+++ b/ABNScheduler.swift
@@ -97,9 +97,9 @@ class ABNScheduler {
     
     ///Schedules the maximum possible number of ABNotification from the ABNQueue
     class func scheduleNotificationsFromQueue() {
-        for _ in 0..<(min(maximumScheduledNotifications, MAX_ALLOWED_NOTIFICATIONS) - scheduledCount()) {
+        for _ in 0..<(min(maximumScheduledNotifications, MAX_ALLOWED_NOTIFICATIONS) - scheduledCount()) where ABNQueue.queue.count() > 0 {
             let notification = ABNQueue.queue.pop()
-            notification?.schedule(fireDate: (notification?.fireDate)!)
+            notification.schedule(fireDate: notification.fireDate!)
         }
     }
     
@@ -268,7 +268,7 @@ private class ABNQueue : NSObject {
     
     ///Removes and returns the head of the queue.
     ///- returns: The head of the queue.
-    private func pop() -> ABNotification? {
+    private func pop() -> ABNotification {
         return notifQueue.removeFirst()
     }
     


### PR DESCRIPTION
.removeFirst() does not return an optional. Therefore if we call on an empty notifQueue the app would crash
