### PR TITLE
Fixed issue with initializer

### DIFF
--- a/ABNScheduler.swift
+++ b/ABNScheduler.swift
@@ -206,7 +206,7 @@ class ABNScheduler {
             return
         }
         
-        print("SCHEDLUED")
+        print("SCHEDULED")
         
         var i = 1
         for note in notifs! {
@@ -504,7 +504,10 @@ open class ABNotification : NSObject, NSCoding, Comparable {
     // MARK: NSCoding
     
     @objc convenience public required init?(coder aDecoder: NSCoder) {
-        guard let localNotification = aDecoder.decodeObject(forKey: "ABNNotification") as? UILocalNotification, let alertBody =  aDecoder.decodeObject(forKey: "ABNAlertBody") as? String, let alertAction = aDecoder.decodeObject(forKey: "ABNAlertAction") as? String, let soundName = aDecoder.decodeObject(forKey: "ABNSoundName") as? String, let repeats = aDecoder.decodeObject(forKey: "ABNRepeats") as? String, let userInfo = aDecoder.decodeObject(forKey: "ABNUserInfo") as? Dictionary<String, AnyObject>, let identifier = aDecoder.decodeObject(forKey: "ABNIdentifier") as? String, let scheduled = aDecoder.decodeObject(forKey: "ABNScheduled") as? Bool else { return nil }
+        guard let localNotification = aDecoder.decodeObject(forKey: "ABNNotification") as? UILocalNotification, let alertBody =  aDecoder.decodeObject(forKey: "ABNAlertBody") as? String, let repeats = aDecoder.decodeObject(forKey: "ABNRepeats") as? String, let userInfo = aDecoder.decodeObject(forKey: "ABNUserInfo") as? Dictionary<String, AnyObject>, let identifier = aDecoder.decodeObject(forKey: "ABNIdentifier") as? String, let scheduled = aDecoder.decodeObject(forKey: "ABNScheduled") as? Bool else { return nil }
+        
+        let alertAction = aDecoder.decodeObject(forKey: "ABNAlertAction") as? String
+        let soundName = aDecoder.decodeObject(forKey: "ABNSoundName") as? String
         
         self.init(notification: localNotification, alertBody: alertBody, alertAction: alertAction, soundName: soundName, identifier: identifier, repeats: Repeats(rawValue: repeats)!, userInfo: userInfo, scheduled: scheduled)
     }


### PR DESCRIPTION
I have updated the PR for the Swift 3 version. Unfortunately it doesn't seem like I can add unit tests to recreate the issue (at least without a significant refactor).

Here are the steps to reproduce:
1. Schedule > 60 notifications so some get stored in the queue. For these notifications don't set either the sound or the alert action properties
2. Save the queue/force quit the app so the singleton ABNQueue gets deallocated
3. Restart the app which triggers the load() and does NSKeyedUnarchiver.unarchiveObject
4. @objc convenience public required init?(coder aDecoder: NSCoder) should then get called for each notification

Anything without a sound or alert action will fail the guard statement in that method and not be put into the queue